### PR TITLE
Release memory used after calling unarycall

### DIFF
--- a/grpc_asyncio/includes/grpc.pxi
+++ b/grpc_asyncio/includes/grpc.pxi
@@ -230,8 +230,9 @@ cdef extern from "grpc/grpc.h":
         grpc_experimental_completion_queue_functor* shutdown_callback,
         void *reserved) nogil
 
-    grpc_completion_queue *grpc_completion_queue_create_for_next(
-        void *reserved) nogil
+    void grpc_completion_queue_shutdown(grpc_completion_queue *cq) nogil
+
+    void grpc_completion_queue_destroy(grpc_completion_queue *cq) nogil
 
     grpc_channel *grpc_insecure_channel_create(
         const char *target,
@@ -260,6 +261,8 @@ cdef extern from "grpc/grpc.h":
         const grpc_slice *host,
         gpr_timespec deadline,
         void *reserved) nogil
+
+    void grpc_call_unref(grpc_call *call) nogil
 
     grpc_call_error grpc_call_start_batch(
         grpc_call *call,

--- a/grpc_asyncio/socket.pyx
+++ b/grpc_asyncio/socket.pyx
@@ -97,6 +97,7 @@ cdef class Socket:
         self.read_buffer = buffer_
  
     cdef void write(self, grpc_slice_buffer * g_slice_buffer, grpc_custom_write_callback g_write_cb):
+        cdef char* start
         buffer_ = bytearray()
         for i in range(g_slice_buffer.count):
             start = grpc_slice_buffer_start(g_slice_buffer, i)

--- a/grpc_asyncio/unarycall.pyx
+++ b/grpc_asyncio/unarycall.pyx
@@ -138,27 +138,27 @@ cdef class _UnaryCall:
             if call_status != GRPC_CALL_OK:
                 self._waiter_call = None
                 raise Exception("Error with grpc_call_start_batch {}".format(call_status))
-            else:
-                await self._waiter_call
 
-                if recv_message_byte_buffer != NULL:
-                    recv_message_reader_status = grpc_byte_buffer_reader_init(
-                        &recv_message_reader,
-                        recv_message_byte_buffer
-                    )
-                    if recv_message_reader_status:
-                        message = bytearray()
-                        while grpc_byte_buffer_reader_next(&recv_message_reader, &recv_message_slice):
-                            recv_message_slice_pointer = grpc_slice_start_ptr(recv_message_slice)
-                            recv_message_slice_length = grpc_slice_length(recv_message_slice)
-                            message += (<char *>recv_message_slice_pointer)[:recv_message_slice_length]
-                            grpc_slice_unref(recv_message_slice)
-                        grpc_byte_buffer_reader_destroy(&recv_message_reader)
-                        return bytes(message)
-                    else:
-                        return None
+            await self._waiter_call
+
+            if recv_message_byte_buffer != NULL:
+                recv_message_reader_status = grpc_byte_buffer_reader_init(
+                    &recv_message_reader,
+                    recv_message_byte_buffer
+                )
+                if recv_message_reader_status:
+                    message = bytearray()
+                    while grpc_byte_buffer_reader_next(&recv_message_reader, &recv_message_slice):
+                        recv_message_slice_pointer = grpc_slice_start_ptr(recv_message_slice)
+                        recv_message_slice_length = grpc_slice_length(recv_message_slice)
+                        message += (<char *>recv_message_slice_pointer)[:recv_message_slice_length]
+                        grpc_slice_unref(recv_message_slice)
+                    grpc_byte_buffer_reader_destroy(&recv_message_reader)
+                    return bytes(message)
                 else:
                     return None
+            else:
+                return None
         finally:
             grpc_byte_buffer_destroy(send_message_byte_buffer)
             grpc_metadata_array_destroy(&recv_trailing_metadata)

--- a/grpc_asyncio/unarycall.pyx
+++ b/grpc_asyncio/unarycall.pyx
@@ -18,6 +18,10 @@ cdef class _UnaryCall:
         self.watcher_call.obj = <cpython.PyObject *> self
         self._waiter_call = None
 
+    def __dealloc__(self):
+        grpc_completion_queue_shutdown(self.cq)
+        grpc_completion_queue_destroy(self.cq)
+
     def __repr__(self):
         class_name = self.__class__.__name__ 
         id_ = id(self)
@@ -45,6 +49,7 @@ cdef class _UnaryCall:
         cdef grpc_slice message_slice
         cdef grpc_byte_buffer * message_byte_buffer
         cdef grpc_metadata_array recv_initial_metadata
+        cdef grpc_byte_buffer * send_message_byte_buffer
         cdef grpc_byte_buffer * recv_message_byte_buffer
         cdef grpc_byte_buffer_reader recv_message_reader
         cdef bint recv_message_reader_status
@@ -58,6 +63,7 @@ cdef class _UnaryCall:
         cdef grpc_call_error call_status
 
         recv_message_byte_buffer = NULL
+        send_message_byte_buffer = NULL
 
         method_slice = grpc_slice_from_copied_buffer(
             <const char *> method,
@@ -128,27 +134,38 @@ cdef class _UnaryCall:
             NULL
         )
 
-        if call_status != GRPC_CALL_OK:
-            self._waiter_call = None
-            raise Exception("Error with grpc_call_start_batch {}".format(call_status))
-
-        await self._waiter_call
-
-        if recv_message_byte_buffer != NULL:
-            recv_message_reader_status = grpc_byte_buffer_reader_init(
-                &recv_message_reader,
-                recv_message_byte_buffer
-            )
-            if recv_message_reader_status:
-                message = bytearray()
-                while grpc_byte_buffer_reader_next(&recv_message_reader, &recv_message_slice):
-                    recv_message_slice_pointer = grpc_slice_start_ptr(recv_message_slice)
-                    recv_message_slice_length = grpc_slice_length(recv_message_slice)
-                    message += (<char *>recv_message_slice_pointer)[:recv_message_slice_length]
-                    grpc_slice_unref(recv_message_slice)
-                grpc_byte_buffer_reader_destroy(&recv_message_reader)
-                return bytes(message)
+        try:
+            if call_status != GRPC_CALL_OK:
+                self._waiter_call = None
+                raise Exception("Error with grpc_call_start_batch {}".format(call_status))
             else:
-                return None
-        else:
-            return None
+                await self._waiter_call
+
+                if recv_message_byte_buffer != NULL:
+                    recv_message_reader_status = grpc_byte_buffer_reader_init(
+                        &recv_message_reader,
+                        recv_message_byte_buffer
+                    )
+                    if recv_message_reader_status:
+                        message = bytearray()
+                        while grpc_byte_buffer_reader_next(&recv_message_reader, &recv_message_slice):
+                            recv_message_slice_pointer = grpc_slice_start_ptr(recv_message_slice)
+                            recv_message_slice_length = grpc_slice_length(recv_message_slice)
+                            message += (<char *>recv_message_slice_pointer)[:recv_message_slice_length]
+                            grpc_slice_unref(recv_message_slice)
+                        grpc_byte_buffer_reader_destroy(&recv_message_reader)
+                        return bytes(message)
+                    else:
+                        return None
+                else:
+                    return None
+        finally:
+            grpc_byte_buffer_destroy(send_message_byte_buffer)
+            grpc_metadata_array_destroy(&recv_trailing_metadata)
+            grpc_byte_buffer_destroy(recv_message_byte_buffer)
+            grpc_metadata_array_destroy(&recv_initial_metadata)
+            grpc_slice_unref(recv_status_details)
+            if recv_error_string != NULL:
+                gpr_free(<void*>recv_error_string)
+            grpc_call_unref(call)
+            gpr_free(ops)


### PR DESCRIPTION
With this change the memory is apparently released at each unarycall. Has been spotted
that the memory keeps increasing but a very small pace, which can be also reproduced with
the synchronous version but with an even smaller increment.

Now, longer load tests can be executed without consuming the whole memory, even though further
investigations will be needed to address this likely memory leak that might be there from the
very beginning.

Addresses issue #2